### PR TITLE
feat: add mock data scripts for DB recommendation and Kafka assist

### DIFF
--- a/mock_data/db_recommendation.py
+++ b/mock_data/db_recommendation.py
@@ -1,0 +1,352 @@
+"""Mock Chatbot - Simulates DatabaseRecommendationChatbot without LLM or Jira dependencies"""
+
+import re
+from typing import Dict, Any, Optional
+
+
+# ---------------------------------------------------------------------------
+# Mocked back-end responses (mirror functions.py logic without real calls)
+# ---------------------------------------------------------------------------
+
+_MOCK_RECOMMENDATIONS: Dict[str, Dict[str, Any]] = {
+    "postgresql_acid_opensource":   {"recommendation": "PostgreSQL",   "reason": "Open-source app without Microsoft dependencies",          "status": "success"},
+    "postgresql_acid_proprietary":  {"recommendation": "PostgreSQL",   "reason": "Proprietary app without Microsoft dependencies",          "status": "success"},
+    "postgresql_large_db":          {"recommendation": "PostgreSQL",   "reason": "Large database (>300 GB) without ACID requirements",      "status": "success"},
+    "mssql_acid_opensource":        {"recommendation": "MS SQL Server", "reason": "Open-source app with Microsoft dependencies",            "status": "success"},
+    "mssql_acid_proprietary":       {"recommendation": "MS SQL Server", "reason": "Proprietary app with Microsoft dependencies",            "status": "success"},
+    "mysql_small_db":               {"recommendation": "MySQL",         "reason": "Small database (<300 GB) without ACID requirements",     "status": "success"},
+    "analytics":                    {"recommendation": "Feature under development", "reason": "Analytics support coming soon",             "status": "not_supported"},
+    "unstructured":                 {"recommendation": "Feature under development", "reason": "Unstructured data support coming soon",      "status": "not_supported"},
+    "vendor":                       {"recommendation": "Contact DBA Team", "reason": "Vendor apps require specialised review",
+                                     "email": "dl-edsdelivery@citizensbank.com",                                                           "status": "dba_review"},
+}
+
+_MOCK_JIRA_TICKET = {
+    "success": True,
+    "ticket_id": "EDE-demo-1042",
+    "jira_link": "https://citizensbank-sandbox.atlassian.net/browse/EDE-demo-1042",
+    "error": None,
+}
+
+
+# ---------------------------------------------------------------------------
+# Business info extractor
+# ---------------------------------------------------------------------------
+
+def _extract_business_info(text: str) -> Dict[str, Optional[str]]:
+    """Extract architect name, architecture review status, epic ID, and SYSID from text."""
+    info: Dict[str, Optional[str]] = {
+        "architect_name": None,
+        "arch_review": None,
+        "epic_id": None,
+        "sysid": None,
+    }
+
+    # Architect name — "my name is John Smith", "architect: John Smith",
+    #                  "architect is John Smith", "architect name John Smith"
+    name_match = re.search(
+        r"(?:my name is|i am|architect(?:\s+name)?\s+is|architect(?:\s+name)?[\s:]+)\s*([^,()\n]+)",
+        text, re.IGNORECASE
+    )
+    if name_match:
+        info["architect_name"] = name_match.group(1).strip().rstrip(",")
+
+    # Architecture review — "arch review yes/no", "architecture review: yes",
+    #                        "completed an Architecture Review" → Yes
+    review_match = re.search(
+        r"arch(?:itecture)?\s+review[\s:]+?(yes|no)\b",
+        text, re.IGNORECASE
+    )
+    if review_match:
+        info["arch_review"] = review_match.group(1).capitalize()
+    elif re.search(r"completed\s+(?:an?\s+)?arch(?:itecture)?\s+review", text, re.IGNORECASE):
+        info["arch_review"] = "Yes"
+
+    # Epic / Initiative ID — "epic EPIC-123", "(EPIC-2024)", "initiative INI-456"
+    epic_match = re.search(
+        r"(?:(?:epic|initiative)[\s:(]+([A-Z0-9][-A-Z0-9]+)|\(([A-Z]+-\d+)\))",
+        text, re.IGNORECASE
+    )
+    if epic_match:
+        info["epic_id"] = (epic_match.group(1) or epic_match.group(2)).upper()
+
+    # SYSID — "SYSID-12345" (standalone), "sysid: SYS-001", "business mapping BM-99"
+    sysid_match = re.search(r"\bSYSID-\w+\b", text, re.IGNORECASE)
+    if sysid_match:
+        info["sysid"] = sysid_match.group(0).upper()
+    else:
+        sysid_match = re.search(
+            r"(?:sysid|sys id|business mapping)[\s:]+([A-Z0-9][-A-Z0-9]+)",
+            text, re.IGNORECASE
+        )
+        if sysid_match:
+            info["sysid"] = sysid_match.group(1).upper()
+
+    return info
+
+
+# ---------------------------------------------------------------------------
+# Simple keyword classifier
+# ---------------------------------------------------------------------------
+
+def _classify(text: str) -> str:
+    """Return a recommendation key based on keywords found in *text*."""
+    t = text.lower()
+
+    # Helpers: detect negated vs affirmed keywords
+    def _negated(keyword: str) -> bool:
+        """Return True if *keyword* is negated nearby (within ~6 words)."""
+        # Direct adjacency: "no microsoft", "without microsoft"
+        direct = rf"\b(no|not|without|non)\s+{re.escape(keyword)}"
+        if re.search(direct, t):
+            return True
+        # Indirect: "do not have ... microsoft licensing" (up to 6 words gap)
+        indirect = rf"\b(do not|don't|does not|doesn't|have no|without)\b[\w\s]{{0,40}}{re.escape(keyword)}"
+        if re.search(indirect, t):
+            return True
+        return False
+
+    def _affirmed(keyword: str) -> bool:
+        return keyword in t and not _negated(keyword)
+
+    # Data-nature shortcuts
+    if "analytics" in t:
+        return "analytics"
+    if "unstructured" in t:
+        return "unstructured"
+    if "vendor" in t:
+        return "vendor"
+
+    # Explicit DB name hints (direct shortcut for testing)
+    if "mysql" in t:
+        return "mysql_small_db"
+    ms_keywords = ["ms sql", "mssql", "sql server", "microsoft"]
+    has_ms = any(_affirmed(kw) for kw in ms_keywords)
+    if has_ms:
+        open_src = _affirmed("open source") or _affirmed("opensource")
+        return "mssql_acid_opensource" if open_src else "mssql_acid_proprietary"
+    if "postgresql" in t or "postgres" in t:
+        if "large" in t or ">300" in t or "big" in t:
+            return "postgresql_large_db"
+        return "postgresql_acid_opensource"
+
+    # ACID / size decision path
+    acid_no  = _negated("acid") or "no acid" in t or "acid no" in t or re.search(r"acid\s*[=:]\s*no", t) is not None
+    acid_yes = re.search(r"\bacid\b", t) and not acid_no
+
+    if acid_yes:
+        open_src = _affirmed("open source") or _affirmed("opensource")
+        ms_dep   = _affirmed("microsoft") or _affirmed("ms licensing")
+        if ms_dep:
+            return "mssql_acid_opensource" if open_src else "mssql_acid_proprietary"
+        return "postgresql_acid_opensource" if open_src else "postgresql_acid_proprietary"
+
+    if acid_no:
+        if "large" in t or ">300" in t or "big" in t:
+            return "postgresql_large_db"
+        if "small" in t or "<300" in t:
+            return "mysql_small_db"
+
+    if "large" in t or ">300" in t:
+        return "postgresql_large_db"
+    if "small" in t or "<300" in t:
+        return "mysql_small_db"
+
+    # Default: not enough info yet
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Public API – single str input, returns str
+# ---------------------------------------------------------------------------
+
+def process_user_input(user_message: str) -> str:
+    """
+    Mock entry point for the DatabaseRecommendationChatbot.
+
+    Accepts a plain-text *user_message* string and returns a fully-formatted
+    chatbot response string with a mocked database recommendation (and a
+    mocked Jira ticket when the user confirms).
+
+    Parameters
+    ----------
+    user_message : str
+        Any natural-language request, e.g.
+        ``"I need a transactional PostgreSQL DB, no ACID needed, small size"``
+
+    Returns
+    -------
+    str
+        Formatted chatbot response.
+
+    Examples
+    --------
+    >>> print(process_user_input("transactional, structured, CFG developed, ACID yes, open source, no microsoft"))
+    >>> print(process_user_input("analytics use case"))
+    >>> print(process_user_input("yes"))   # confirm Jira ticket creation
+    """
+    if not isinstance(user_message, str):
+        raise TypeError(f"user_message must be str, got {type(user_message).__name__}")
+
+    t = user_message.strip().lower()
+
+    # ---- Jira-ticket confirmation ----------------------------------------
+    if t in {"yes", "y", "create ticket", "yes please", "create jira", "create jira ticket"}:
+        return _format_jira_response(_MOCK_JIRA_TICKET)
+
+    # ---- Ticket decline -----------------------------------------------------
+    if t in {"no", "n", "no thanks", "skip", "no ticket"}:
+        return "Understood. No ticket will be created. Is there anything else I can help you with?"
+
+    # ---- Reset / start-over -------------------------------------------------
+    if t in {"start over", "reset", "begin again", "restart"}:
+        return "Sure, let's start fresh. What would you like help with?"
+
+    # ---- Classify and respond -----------------------------------------------
+    key = _classify(user_message)
+    business_info = _extract_business_info(user_message)
+
+    if key == "unknown":
+        return _format_clarification_response(user_message)
+
+    rec = _MOCK_RECOMMENDATIONS[key]
+    return _format_recommendation_response(rec, business_info, rec_key=key)
+
+
+# ---------------------------------------------------------------------------
+# Tech info inference from recommendation key
+# ---------------------------------------------------------------------------
+
+_TECH_INFO_BY_KEY: Dict[str, Dict[str, str]] = {
+    "postgresql_acid_opensource":  {"data_nature": "Transactional", "data_structure": "Structured", "app_type": "CFG Developed", "acid_compliance": "Yes", "is_open_source": "Yes",  "ms_licensing": "No",  "vendor_recommended_db": "N/A"},
+    "postgresql_acid_proprietary": {"data_nature": "Transactional", "data_structure": "Structured", "app_type": "CFG Developed", "acid_compliance": "Yes", "is_open_source": "No",   "ms_licensing": "No",  "vendor_recommended_db": "N/A"},
+    "postgresql_large_db":         {"data_nature": "Transactional", "data_structure": "Structured", "app_type": "CFG Developed", "acid_compliance": "No",  "is_open_source": "N/A",  "ms_licensing": "N/A", "vendor_recommended_db": "N/A"},
+    "mssql_acid_opensource":       {"data_nature": "Transactional", "data_structure": "Structured", "app_type": "CFG Developed", "acid_compliance": "Yes", "is_open_source": "Yes",  "ms_licensing": "Yes", "vendor_recommended_db": "N/A"},
+    "mssql_acid_proprietary":      {"data_nature": "Transactional", "data_structure": "Structured", "app_type": "CFG Developed", "acid_compliance": "Yes", "is_open_source": "No",   "ms_licensing": "Yes", "vendor_recommended_db": "N/A"},
+    "mysql_small_db":              {"data_nature": "Transactional", "data_structure": "Structured", "app_type": "CFG Developed", "acid_compliance": "No",  "is_open_source": "N/A",  "ms_licensing": "N/A", "vendor_recommended_db": "N/A"},
+    "analytics":                   {"data_nature": "Analytics",     "data_structure": "N/A",        "app_type": "N/A",           "acid_compliance": "N/A", "is_open_source": "N/A",  "ms_licensing": "N/A", "vendor_recommended_db": "N/A"},
+    "unstructured":                {"data_nature": "Transactional", "data_structure": "Unstructured","app_type": "N/A",           "acid_compliance": "N/A", "is_open_source": "N/A",  "ms_licensing": "N/A", "vendor_recommended_db": "N/A"},
+    "vendor":                      {"data_nature": "Transactional", "data_structure": "Structured", "app_type": "Vendor Application", "acid_compliance": "N/A", "is_open_source": "N/A", "ms_licensing": "N/A", "vendor_recommended_db": "Yes"},
+}
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+def _format_jira_preview(rec: Dict[str, Any], info: Dict[str, Optional[str]], rec_key: str) -> str:
+    """Build the Jira ticket preview shown before asking the user to confirm."""
+    tech = _TECH_INFO_BY_KEY.get(rec_key, {})
+    biz  = info or {}
+
+    description = (
+        "Database choice analysis for the application\n\n"
+        "Application Information:\n"
+        f"  1. Application Architect/Owner: {biz.get('architect_name') or 'N/A'}\n"
+        f"  2. Architecture Review Status: {biz.get('arch_review') or 'N/A'}\n"
+        f"  3. Epic/Initiative Link: {biz.get('epic_id') or 'N/A'}\n"
+        f"  4. SYSID/Business Mapping Available: {biz.get('sysid') or 'N/A'}\n\n"
+        "Technical Requirements:\n"
+        f"  1. What is the nature of data you intend to store? {tech.get('data_nature', 'N/A')}\n"
+        f"  2. How do you define your data? {tech.get('data_structure', 'N/A')}\n"
+        f"  3. Is it a Vendor Application (COTS) or CFG developed? {tech.get('app_type', 'N/A')}\n"
+        f"  4. Does your application need strict ACID SQL Compliance? {tech.get('acid_compliance', 'N/A')}\n"
+        f"  5. Is your Application Open source? {tech.get('is_open_source', 'N/A')}\n"
+        f"  6. Does your Application have Microsoft licensing dependency? {tech.get('ms_licensing', 'N/A')}\n"
+        f"  7. Does Vendor recommend any Database types? {tech.get('vendor_recommended_db', 'N/A')}\n\n"
+        f"Recommendation:\n"
+        f"  {rec.get('recommendation', 'N/A')}"
+    )
+
+    return (
+        "**Jira Ticket Preview:**\n"
+        "```\n"
+        f"Summary    : Database choice analysis\n"
+        f"Description:\n{description}\n"
+        "```"
+    )
+
+
+def _format_recommendation_response(rec: Dict[str, Any], info: Dict[str, Optional[str]] = None, rec_key: str = "") -> str:
+    status  = rec.get("status", "")
+    preview = _format_jira_preview(rec, info or {}, rec_key)
+
+    if status == "not_supported":
+        return (
+            "## Database Recommendation\n\n"
+            f"**Result:** {rec['recommendation']}\n\n"
+            f"**Details:** {rec['reason']}\n\n"
+            f"{preview}\n\n"
+            "Would you like me to create a Jira ticket for this recommendation? [Yes] / [No]"
+        )
+
+    if status == "dba_review":
+        return (
+            "## Database Recommendation\n\n"
+            f"**Result:** {rec['recommendation']}\n\n"
+            f"**Reason:** {rec['reason']}\n\n"
+            f"Please reach out to the DBA team at **{rec.get('email', 'dl-edsdelivery@citizensbank.com')}**.\n\n"
+            f"{preview}\n\n"
+            "Would you like me to create a Jira ticket for this recommendation? [Yes] / [No]"
+        )
+
+    # success
+    return (
+        "## Database Recommendation\n\n"
+        f"Based on your requirements, we recommend: **{rec['recommendation']}**\n\n"
+        f"**Justification:** {rec['reason']}\n\n"
+        f"{preview}\n\n"
+        "Would you like me to create a Jira ticket for this recommendation? [Yes] / [No]"
+    )
+
+
+def _format_jira_response(ticket: Dict[str, Any]) -> str:
+    if not ticket.get("success"):
+        return f"❌ Jira Error: {ticket.get('error', 'Unknown error')}"
+
+    return (
+        "✅ Jira Ticket Created!\n\n"
+        f"**Ticket ID:** {ticket['ticket_id']}\n"
+        f"**Link:** {ticket['jira_link']}"
+    )
+
+
+def _format_clarification_response(user_message: str) -> str:
+    return (
+        "Thanks for your request! To generate a recommendation I need a few details:\n\n"
+        "1. **Data Nature** – Is this *Transactional* or *Analytics*?\n"
+        "2. **Data Structure** – Is the data *Structured* or *Unstructured*?\n"
+        "3. **Application Type** – *Vendor Application* or *CFG Developed*?\n"
+        "4. **ACID Compliance** – Required? *Yes* / *No*\n"
+        "   - If Yes → Is it *Open Source*? Does it have *Microsoft licensing* dependencies?\n"
+        "   - If No  → Is the database size *large (>300 GB)*?\n\n"
+        "Feel free to answer all at once or one at a time."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Quick smoke-test
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    test_cases = [
+        "my name is John Smith, arch review yes, epic EPIC-2024-DB, sysid SYS-12345, transactional, structured, CFG developed, ACID yes, open source, no microsoft licensing",
+        "architect: Jane Doe, architecture review no, sysid BM-999, transactional, structured, CFG developed, ACID yes, no open source, microsoft licensing yes",
+        "my name is Alice Brown, sysid SYS-777, transactional, structured, CFG developed, no ACID, large database",
+        "transactional, structured, CFG developed, no ACID, small database",
+        "analytics use case",
+        "unstructured data",
+        "vendor application",
+        "I need a postgresql database",
+        "I need a mysql database",
+        "I need an MS SQL Server",
+        "yes",
+        "no",
+        "start over",
+        "tell me about your services",  # unknown → clarification
+    ]
+
+    for msg in test_cases:
+        print(f"\nUser: {msg}")
+        print(f"Bot:  {process_user_input(msg)}")
+        print("-" * 60)

--- a/mock_data/kafka_assist.py
+++ b/mock_data/kafka_assist.py
@@ -1,0 +1,87 @@
+def get_mock_response(question: str) -> str:
+    q = question.lower()
+
+    qa_data = [
+        {
+            "keywords": ["topic", "create", "modify", "portal"],
+            "response": """Ah, I see what you mean. Let's fix that…
+
+You can only view topics and schemas in the Kafka Self Service Portal by default. To get the power to create or modify topics and schemas, you need to:
+
+- Raise a Sailpoint access request for the group "dso-kafka-portal-app-admin"
+- Once your access is approved, log out and log back in (or clear your browser cache) to activate your new permissions
+
+Until you have that admin access, you're stuck in "read-only" mode—no rockstar moves like creating or editing topics for you just yet!
+
+**Sources:**
+- [Kafka integration process](/spaces/STREAM/pages/207135684/Kafka+integration+process)
+- [Kafka use case integration process](/spaces/STREAM/pages/582802270/Kafka+use+case+integration+process)"""
+        },
+        {
+            "keywords": ["integration", "issue", "help", "jira"],
+            "response": """Boom! Here's how you get help with an existing Kafka integration issue:
+
+- **Create a Jira ticket** for the Kafka team. The recommended way is to clone the Jira story **EDE-203568** for your issue.
+- Make sure to attach logs and provide a summary and details about your issue in the ticket.
+
+You can find this process in the Kafka integration documentation. If you're feeling extra, you can also use the Kafka Self Service Portal for existing integrations.
+
+Rock on! :guitar:
+
+**Sources:**
+- [Kafka integration process](/spaces/STREAM/pages/207135684/Kafka+integration+process)
+- [Issues with Kafka Integration?](/spaces/STREAM/pages/420610323/Issues+with+Kafka+Integration)"""
+        },
+        {
+            "keywords": ["service account", "api key", "sysid"],
+            "response": """Rock on! Here's what you need for Service Account and API key creation:
+
+- **SYSID** (System ID) and **App Name/Description** are required inputs when creating a Service Account.
+- When you create a Service Account, an **API key and secret** are generated for it. You'll need to save these right away—this is the only time you'll see them!
+- Make sure you store the API key and secret securely (like in a vault), since you'll need them to configure your Kafka client applications.
+- Remember: Service Account names can't be changed after creation, so get it right the first time.
+
+Boom! That's your Service Account starter pack. :the_horns:
+
+**Sources:**
+- [Service Accounts](/spaces/STREAM/pages/120792089/Service+Accounts)
+- [3.1.1 Create Service Account](/spaces/STREAM/pages/235608292/3.1.1+Create+Service+Account)"""
+        },
+        {
+            "keywords": ["authentication", "authorization", "auth", "okta", "ad group"],
+            "response": """Rock on! Here's how authentication and authorization are handled in the Kafka Self Service Portal:
+
+- **Authentication** is done via SSO/Okta. When you log in, Okta authenticates you and passes your AD group memberships to the portal.
+- **Authorization** is managed using AD Groups. Your group membership determines what you can do in the portal.
+- To access the portal (even just to view), you must follow the SailPoint Access request process to get added to the right AD group.
+- For create/modify/delete powers, you need to be in the Admin AD group (typically as a Lead Developer), which also requires a SailPoint request.
+- The portal uses LDAP to verify email addresses when developers enter approver emails.
+
+Boom! That's the backstage pass to portal access. :the_horns:
+
+**Sources:**
+- [Kafka Self Service Portal 2.0 - Solution Design](/spaces/STREAM/pages/348189939/Kafka+Self+Service+Portal+2.0+-+Solution+Design)
+- [Kafka Self Service Portal 2.0 - Solution Approach](/spaces/STREAM/pages/353900318/Kafka+Self+Service+Portal+2.0+-+Solution+Approach)"""
+        }
+    ]
+
+    # Matching logic: count keyword hits
+    best_match = None
+    best_score = 0
+
+    for item in qa_data:
+        score = sum(1 for kw in item["keywords"] if kw in q)
+
+        if score > best_score:
+            best_score = score
+            best_match = item
+
+    # Require at least 1 keyword match
+    if best_score >= 1:
+        return best_match["response"]
+
+    return "No matching answer found."
+
+
+# Example
+# print(get_mock_response("I cannot create topic in kafka portal"))

--- a/mock_data/readme_db_recommendation.txt
+++ b/mock_data/readme_db_recommendation.txt
@@ -1,0 +1,61 @@
+DB Recommendation Chatbot - Example Questions
+==============================================
+
+Use these questions to test the process_user_input() function or the POST /chat API endpoint.
+
+
+1. Full Natural Language Input (recommended)
+--------------------------------------------
+- "I need a database for a new microservice. We have completed an Architecture Review, architect is arun reddy (EPIC-2024) for system SYSID-12345. The data is transactional and structured, the solution is CFG Developed, and we require ACID compliance. We prefer open-source tooling and do not have a Microsoft licensing agreement in place"
+- "my name is John Smith, arch review yes, epic EPIC-2024-DB, sysid SYS-12345, transactional, structured, CFG developed, ACID yes, open source, no microsoft licensing"
+- "architect: Jane Doe, architecture review no, sysid BM-999, transactional, structured, CFG developed, ACID yes, no open source, microsoft licensing yes"
+- "my name is Alice Brown, sysid SYS-777, transactional, structured, CFG developed, no ACID, large database"
+
+
+2. PostgreSQL Recommendations
+------------------------------
+- "transactional, structured, CFG developed, ACID yes, open source, no microsoft licensing"
+- "transactional, structured, CFG developed, ACID yes, no open source, no microsoft"
+- "transactional, structured, CFG developed, no ACID, large database"
+- "I need a postgresql database"
+
+
+3. MySQL Recommendation
+------------------------
+- "transactional, structured, CFG developed, no ACID, small database"
+- "I need a mysql database"
+
+
+4. MS SQL Server Recommendations
+----------------------------------
+- "transactional, structured, CFG developed, ACID yes, open source, microsoft licensing yes"
+- "transactional, structured, CFG developed, ACID yes, no open source, microsoft licensing yes"
+- "I need an MS SQL Server"
+
+
+5. Feature Under Development
+-----------------------------
+- "analytics use case"
+- "unstructured data"
+
+
+6. Contact DBA Team
+--------------------
+- "vendor application"
+
+
+7. Follow-up Responses
+------------------------
+- "yes"              → creates mocked Jira ticket (EDE-demo-1042)
+- "no"               → declines ticket creation
+- "start over"       → resets conversation
+
+
+8. Clarification (insufficient info)
+--------------------------------------
+- "tell me about your services"
+- "I need a database"
+
+
+#example
+Example  : { "message": "I need a database for a new microservice. We have completed an Architecture Review, architect is arun reddy (EPIC-2024) for system SYSID-12345. The data is transactional and structured, the solution is CFG Developed, and we require ACID compliance. We prefer open-source tooling and do not have a Microsoft licensing agreement in place" }

--- a/mock_data/readme_kafka_assist.txt
+++ b/mock_data/readme_kafka_assist.txt
@@ -1,0 +1,40 @@
+Kafka Q&A Chatbot - Example Questions
+======================================
+
+Use these questions to test the get_mock_response() function or the POST /ask API endpoint.
+
+
+1. Topic / Portal Access
+------------------------
+- "I cannot create topic in kafka portal"
+- "How do I modify a topic in the portal?"
+- "How do I create or modify schemas in the Kafka Self Service Portal?"
+- "Why can I only view topics and not create them?"
+
+
+2. Integration Issues
+---------------------
+- "I have an issue with my Kafka integration, how do I get help?"
+- "How do I raise a Jira ticket for a Kafka issue?"
+- "Where can I find help for an existing Kafka integration?"
+- "What is the process for reporting a Kafka integration problem?"
+
+
+3. Service Account & API Key
+-----------------------------
+- "What do I need to create a service account?"
+- "How do I get an API key for Kafka?"
+- "What inputs are required for service account creation?"
+- "Where do I store my API key and secret after creation?"
+
+
+4. Authentication & Authorization
+----------------------------------
+- "How does authentication work in the Kafka portal?"
+- "How is authorization handled with Okta?"
+- "What AD group do I need to access the Kafka portal?"
+- "How does SSO and Okta work with the Kafka Self Service Portal?"
+
+
+#example
+Example  : { "question": "I cannot create topic in kafka portal" }


### PR DESCRIPTION
## Summary
- Add `mock_data/db_recommendation.py` — mock data script for database recommendation feature
- Add `mock_data/kafka_assist.py` — mock data script for Kafka assist feature
- Add corresponding readme files documenting each script's usage
